### PR TITLE
Capistrano 2.0 compatibility

### DIFF
--- a/lib/squash/rails/capistrano.rb
+++ b/lib/squash/rails/capistrano.rb
@@ -14,11 +14,15 @@
 
 # Capistrano tasks for Rails apps using Squash.
 
-desc "Notifies Squash of a new deploy."
-task 'squash:notify', :roles => :web, :only => {:primary => true}, :except => {:no_release => true} do
-  rails_env = fetch(:rails_env, 'production')
-  run "bundle exec rake squash:notify REVISION=#{real_revision} DEPLOY_ENV=#{rails_env}"
-end
+Capistrano::Configuration.instance.load do
+  namespace :squash do
+    desc "Notifies Squash of a new deploy."
+    task :notify, :roles => :web, :only => {:primary => true}, :except => {:no_release => true} do
+      rails_env = fetch(:rails_env, 'production')
+      run "cd #{current_path} && env RAILS_ENV=#{rails_env} #{fetch(:bundle_cmd, "bundle")} exec rake squash:notify REVISION=#{real_revision} DEPLOY_ENV=#{rails_env}"
+    end
+  end
 
-after 'deploy:restart', 'squash:notify'
-after 'deploy:start', 'squash:notify'
+  after 'deploy:restart', 'squash:notify'
+  after 'deploy:start', 'squash:notify'
+end


### PR DESCRIPTION
Since Capistrano 2.0 recipes must be wrapped in a configuration instance and tasks need to be namespaced. I don't have a long history of Capistrano use, but my short research on the topic led me to believe this is the case.

Also I needed to modify the rake task invocation to cd to deployment path and add RAILS_ENV environment variable to get everything working smoothly.

Tested with current Capistrano release (2.14.1).

Cheers!
